### PR TITLE
Fixes redundantly assigned xml:id 'colB' values

### DIFF
--- a/cases/CASE33766.xml
+++ b/cases/CASE33766.xml
@@ -109,12 +109,12 @@
 <body><div>
 <p><lb/>Margery Hickford his wife <lb/>43 y. <choice><orig>I</orig><reg>J</reg></choice>uly 16 <choice><orig><choice><sic>h</sic><corr>♄</corr></choice></orig><reg type="gloss">Saturday</reg></choice> hor 7. 25 <lb/><choice><orig>ant m</orig><reg>am</reg></choice> 1608 <del type="strikethrough">hed</del> a sw<choice><orig><hi rend="overline">y</hi></orig><reg>ym</reg></choice>ing in her hed <lb/>back ill/</p>
 </div>
-<div><cb xml:id="colB" n="b"/>
+<div><cb xml:id="colB-1" n="b"/>
 <p><lb/>margery Hickford <rs type="address" xml:id="address1" key="PLACE668">of <lb/>fæny stratford</rs>. 43 y <choice><orig>I</orig><reg>J</reg></choice>u<supplied reason="binding">ly</supplied> <lb/>16. <choice><orig><choice><sic>h</sic><corr>♄</corr></choice></orig><reg type="gloss">Saturday</reg></choice>. hor 7. 28 <choice><orig>ant m</orig><reg>am</reg></choice> <lb/>1608. <add place="inline"><foreign xml:lang="la" xml:id="foreign001" decls="#original_source">quærit an si<supplied reason="binding">t</supplied> <lb/>gravida</foreign><seg xml:id="translation001" decls="#translation" xml:lang="en">she asks whether she is pregnant</seg><link type="is-translation-of" target="#foreign001 #translation001"/></add></p>
 </div>
 
 
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 </body>
 </text>
 </TEI>

--- a/cases/CASE44263.xml
+++ b/cases/CASE44263.xml
@@ -103,7 +103,7 @@
 <p><lb/><choice><sic>Alce white of Brackly 45 y <choice><orig>I</orig><reg>J</reg></choice>an 18 h hor <lb/> m 16i7 <add place="inline">6. 40 p m 1617</add> <add place="infralinear">mutch heate in her <lb/>body</add> <add place="inline"><choice><orig>v</orig><reg>u</reg></choice>ryne</add></sic><corr type="delText"/></choice></p>
 </div>
 <figure type="astro" subtype="astroChartDeleted"/>
-<div><cb xml:id="colB" n="b"/>
+<div><cb xml:id="colB-1" n="b"/>
 <p><lb/>Alce White <rs type="address" xml:id="address1" key="PLACE1533" resp="#mhawkins">of <lb/>Brackly</rs> 44 y <choice><sic>Ian</sic><corr type="delText"/></choice> <lb/><choice><orig>I</orig><reg>J</reg></choice>an 18 <choice><orig>♄</orig><reg type="gloss">Saturday</reg></choice> hor 6. 40 p <lb/>m 16<choice><orig>i</orig><reg>1</reg></choice>7.</p>
 </div>
 
@@ -111,7 +111,7 @@
 <p><lb/>Alce White <rs type="address" sameAs="#address1" key="PLACE1533" resp="#mhawkins">of Brackley</rs> 44 y <choice><orig>I</orig><reg>J</reg></choice>an 25 <choice><orig><choice><sic>h</sic><corr>♄</corr></choice></orig><reg type="gloss">Saturday</reg></choice> hor. 6. 40 p m 1617</p>
 </div>
 <figure type="astro" subtype="astroChart"/>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 </body>
 </text>
 </TEI>

--- a/cases/CASE49226.xml
+++ b/cases/CASE49226.xml
@@ -106,13 +106,13 @@
 <p><lb/>m<hi rend="superscript">r</hi> Adolph. Androwes <foreign xml:lang="la" xml:id="foreign001" decls="#original_source">natus</foreign><seg xml:id="translation001" decls="#translation" xml:lang="en">born</seg><link type="is-translation-of" target="#foreign001 #translation001"/> in <placeName xml:id="place1" key="PLACE1303" resp="#mhawkins">Kent</placeName> <lb/><choice><orig>I</orig><reg>J</reg></choice>uli<choice><orig>j</orig><reg>i</reg></choice> 2. <choice><orig>♂</orig><reg type="gloss">Tuesday</reg></choice> h. 7. <choice><orig>ant m</orig><reg>am</reg></choice>. <del type="strikethrough">16</del> 1594.</p>
 </div>
 <figure type="astro" subtype="astroChart"/>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-1" n="b"/>
 <pb xml:id="f95v" n="95v" facs="#abd0210.jpg"/>
 <div><pb xml:id="f96r" n="96r" facs="#abd0211.jpg"/>
 <p><lb/>M<hi rend="superscript">r</hi> Adolph Androwes <foreign xml:lang="la" xml:id="foreign002" decls="#original_source">natus</foreign><seg xml:id="translation002" decls="#translation" xml:lang="en">born</seg><link type="is-translation-of" target="#foreign002 #translation002"/> <lb/>in <placeName sameAs="#place1" key="PLACE1303" resp="#mhawkins">Kent</placeName> <choice><sic>Iuly 2</sic><corr type="delText"/></choice> <add place="supralinear"><choice><sic>Iulij</sic><corr type="delText"/></choice></add> <add place="infralinear"><choice><orig>I</orig><reg>J</reg></choice>uli<choice><orig>j</orig><reg>i</reg></choice> 2.</add> <choice><orig>♂</orig><reg type="gloss">Tuesday</reg></choice> h 7 <lb/><choice><orig>ant m</orig><reg>am</reg></choice> <choice><sic>1594.</sic><corr type="delText"/></choice> <add place="inline">1594.</add></p>
 </div>
 <figure type="astro" subtype="astroChart"/>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 </body>
 </text>
 </TEI>

--- a/cases/CASE50112.xml
+++ b/cases/CASE50112.xml
@@ -114,10 +114,10 @@
 <link type="is-translation-of" target="#foreign002 #translation002"/>
 <figure type="astro" subtype="astroChart"/>
 
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-1" n="b"/>
 <pb xml:id="f91v" n="91v" facs="#cmn0200.jpg"/>
 
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 <pb xml:id="f92r" n="92r" facs="#cmn0201.jpg"/>
 
 </body>

--- a/cases/CASE50159.xml
+++ b/cases/CASE50159.xml
@@ -120,10 +120,10 @@
 </div>
 <figure type="astro" subtype="astroChart"/>
 
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-1" n="b"/>
 <pb xml:id="f103v" n="103v" facs="#cmn0224.jpg"/>
 
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 </body>
 </text>
 </TEI>

--- a/cases/CASE50162.xml
+++ b/cases/CASE50162.xml
@@ -120,19 +120,19 @@
 <p><lb/>M<hi rend="superscript">r</hi> kenelme D. <lb/><add place="supralinear">for his frind</add> 2 Sept<choice><orig>ē</orig><reg>em</reg></choice>b <choice><orig>☉</orig><reg type="gloss">Sunday</reg></choice> h. 8. 20 <choice><orig>ant <lb/>m</orig><reg>am</reg></choice> <del type="strikethrough">1620.</del> 1593. <foreign xml:lang="la" xml:id="foreign001" decls="#original_source">post plenil. <lb/>rectif <choice><orig><g ref="#crossedp"></g></orig><reg>per</reg></choice> Animodar./</foreign><seg xml:id="translation001" decls="#translation" xml:lang="en">after the full moon. Rectified by [the] animodar [method].</seg><link type="is-translation-of" target="#foreign001 #translation001"/></p>
 </div>
 <figure type="astro" subtype="astroChart"/>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-1" n="b"/>
 <pb xml:id="f104v" n="104v" facs="#cmn0226.jpg"/>
 
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 <pb xml:id="f105v" n="105v" facs="#cmn0228.jpg"/>
 
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-3" n="b"/>
 <pb xml:id="f106r" n="106r" facs="#cmn0229.jpg"/>
 
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-4" n="b"/>
 <pb xml:id="f106v" n="106v" facs="#cmn0230.jpg"/>
 
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-5" n="b"/>
 </body>
 </text>
 </TEI>

--- a/cases/CASE53187.xml
+++ b/cases/CASE53187.xml
@@ -138,9 +138,9 @@
 <p><lb/><foreign xml:lang="la" xml:id="foreign001" decls="#original_source">Radix rectificata</foreign><seg xml:id="translation001" decls="#translation" xml:lang="en">Rectified radix</seg><link type="is-translation-of" target="#foreign001 #translation001"/> for <choice><orig>m<hi rend="overline">res</hi></orig><reg>Mrs</reg></choice> Mary Gray may 25 <choice><orig>♃</orig><reg type="gloss">Thursday</reg></choice> h. 12. <lb/><add place="supralinear"><subst><del type="over">7</del><add place="over">8</add></subst></add> <choice><orig>post m</orig><reg>pm</reg></choice>. 34 y. &amp; 8 y sinc had <lb/>the smale pox. 1587. her father dyed 7 y sinc &amp; then began <lb/>her <choice><sic>miseyes</sic><corr>miseryes</corr></choice> <add place="infralinear">had 3 <choice><sic>fyst</sic><corr>fyrst</corr></choice> but lived 4. y. had <choice><orig>y<hi rend="superscript">e</hi></orig><reg>the</reg></choice> smale pox. <lb/>not longe 11 child. 5 dead &amp; 5 live &amp; on <choice><orig>y<hi rend="superscript">t</hi></orig><reg>that</reg></choice> <choice><sic>care</sic><corr>came</corr></choice> not to be quicke.</add><note place="chart">may 1587</note></p>
 </div>
 <figure type="astro" subtype="astroChart"/>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-1" n="b"/>
 <pb xml:id="f108v" n="108v"/>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 <pb xml:id="f109r" n="109r"/>
 </body>
 </text>

--- a/cases/CASE57623.xml
+++ b/cases/CASE57623.xml
@@ -105,7 +105,7 @@
 </div>
 <figure type="astro" subtype="astroChartPartial"/>
 <div>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-1" n="b"/>
 <p><lb/><choice><orig>M<hi rend="overline">res</hi></orig><reg>Mrs</reg></choice> Eliz Connyers <foreign xml:lang="la" xml:id="foreign002" decls="#original_source">nata</foreign><seg xml:id="translation002" decls="#translation" xml:lang="en">born</seg><link type="is-translation-of" target="#foreign002 #translation002"/> <lb/><choice><orig>I</orig><reg>J</reg></choice>an 24 <choice><orig>♂</orig><reg type="gloss">Tuesday</reg></choice> h. 10 30 p m 1598 <add place="infralinear">h. 9 p. m 159<subst><del type="over">9</del><add place="over">8</add></subst></add><note place="chart">frentick &amp; mad</note></p>
 </div>
 <figure type="astro" subtype="astroChart"/>
@@ -114,7 +114,7 @@
 <p><lb/><choice><orig>M<hi rend="overline">res</hi></orig><reg>Mrs</reg></choice> Eliz. Comyers now <lb/>Barkley by mariage <foreign xml:lang="la" xml:id="foreign003" decls="#original_source">Nata</foreign><seg xml:id="translation003" decls="#translation" xml:lang="en">Born</seg><link type="is-translation-of" target="#foreign003 #translation003"/> <lb/><choice><orig>I</orig><reg>J</reg></choice>an 24 <choice><orig>♂</orig><reg type="gloss">Tuesday</reg></choice> h. 9 p m 1598. <lb/><choice><sic>mayed</sic><corr>maryed</corr></choice> about 15. <subst><del type="over"><gap reason="del" extent="1" unit="chars"/></del><add place="over">ae</add></subst>leaven yers <lb/>2 children boath dead</p>
 </div>
 <figure type="astro" subtype="astroChart"/>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 </body>
 </text>
 </TEI>

--- a/cases/CASE65597.xml
+++ b/cases/CASE65597.xml
@@ -97,11 +97,11 @@
 <text xml:lang="en">
 <body><div>
 <p><lb/><del type="erased">The<add place="inline"><unclear cert="low" reason="hand">ms</unclear></add> <subst><del type="over"><g ref="#crossedp"></g></del><add place="over">b</add></subst></del>l<subst><del type="over">iamēt</del><add place="over">ssard</add></subst> <lb/>Speach. <add place="supralinear">made in <choice><orig>y<hi rend="superscript">e</hi></orig><reg>the</reg></choice> <choice><orig><choice><sic><g ref="#crossedp"></g>liamet</sic><corr><g ref="#crossedp"></g>liamēt</corr></choice></orig><reg>parliament</reg></choice></add> <lb/>march 17. <choice><orig>☾</orig><reg type="gloss">Monday</reg></choice> <lb/>h 3. 30 p m 1628 <add place="infralinear">the kings speach made in <choice><orig>y<hi rend="superscript">e</hi></orig><reg>the</reg></choice> <lb/><choice><orig><choice><sic><g ref="#crossedp"></g>liamet</sic><corr><g ref="#crossedp"></g>liamēt</corr></choice></orig><reg>parliament</reg></choice></add></p>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-1" n="b"/>
 <p><lb/>the king brake of <lb/>the <choice><orig><g ref="#crossedp"></g></orig><reg>par</reg></choice>liament after his subsy was <lb/>granted <lb/><choice><orig>v</orig><reg>u</reg></choice>pp<choice><orig>ō</orig><reg>on</reg></choice> great displeasure</p>
 </div>
 <figure type="astro" subtype="astroChart"/>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 </body>
 </text>
 </TEI>

--- a/cases/CASE66257.xml
+++ b/cases/CASE66257.xml
@@ -105,10 +105,10 @@
 <text xml:lang="en">
 <body><div>
 <p><lb/><choice><orig>I</orig><reg>J</reg></choice>ohn Armitages wife 2<subst><del type="over">6</del><add place="over">8</add></subst> y <lb/><choice><orig>I</orig><reg>J</reg></choice>une 2 <choice><orig>☾</orig><reg type="gloss">Monday</reg></choice> h. <subst><del type="strikethrough">2. 45</del> <add place="supralinear">3</add></subst> p m <lb/>1628 <add place="lineBeginning"><rs type="address" xml:id="address1" key="PLACE1782" resp="#mhawkins">of Toceter</rs></add></p>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-1" n="b"/>
 <p><lb/><choice><orig>I</orig><reg>J</reg></choice>one Armitage <rs sameAs="#address1">of <lb/>Toceter</rs> 28 y h 3. p m 1628</p>
 </div>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 </body>
 </text>
 </TEI>

--- a/cases/CASE73135.xml
+++ b/cases/CASE73135.xml
@@ -127,12 +127,12 @@
 </div>
 <figure type="astro" subtype="astroChart"/>
 <div>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-1" n="b"/>
 <p><lb/>my lady Cleeveland <lb/>would not have <lb/>him to take any <lb/>physick because <lb/>he hath taken clyst <lb/>&amp; purge &amp; is very <lb/>soluble</p>
 <p><lb/>Craveth my advise <lb/>&amp; would have Diasc<gap extent="unclear" reason="binding" cert="low"/></p>
 </div>
 <cb xml:id="colA" n="a"/>
-<cb xml:id="colB" n="b"/>
+<cb xml:id="colB-2" n="b"/>
 </body>
 </text>
 </TEI>


### PR DESCRIPTION
i  found some mal-formed  documents with redundantly assigned xml:id values. a applied a differentiation by enumerating them in a fashion that was already used in other documents.